### PR TITLE
Additional ICS file for only public events

### DIFF
--- a/kalenderscraper.py
+++ b/kalenderscraper.py
@@ -74,6 +74,11 @@ cal = Calendar()
 cal.add('prodid', '-//wiki.muc.ccc.de Kalenderexport//')
 cal.add('version', '2.0')
 
+# Separate calendar for public events
+cal_public = Calendar()
+cal_public.add('prodid', '-//wiki.muc.ccc.de Kalenderexport Public//')
+cal_public.add('version', '2.0')
+
 for date in accumulate(dates):
 
     event = Event()
@@ -124,19 +129,25 @@ for date in accumulate(dates):
     # 255 characters for this property.
     uid = 'wikical' + date[0] + '.' + date[1] + '.' \
             + date[3].replace(" ","") + '.' \
-            + date[2] + '@api.muc.ccc.de' 
+            + date[2] + '@api.muc.ccc.de'
     uid = uid.replace(':', '.')
 
     event.add('uid', uid)
 
     cal.add_component(event)
 
+    if date[4] and int(date[4]) == 1:
+        cal_public.add_component(event)
 
 path = os.path.dirname(os.path.realpath(__file__))
+
 fhandle = open(path + '/wiki_kalender.ics', "w+")
 fhandle.write(cal.to_ical())
 fhandle.close()
 
+fhandle = open(path + '/wiki_kalender_public.ics', "w+")
+fhandle.write(cal_public.to_ical())
+fhandle.close()
 
 # Export next event to JSON file
 for date in accumulate(dates):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+beautifulsoup4==4.4.1
+html5lib==0.9999999
+icalendar==3.9.2
+python-dateutil==2.5.2
+pytz==2016.3
+requests==2.9.1
+six==1.10.0


### PR DESCRIPTION
Generate an additional ICS file that only contains events which are marked as public.

This is the result of a request to delete certain non-public events from http://munichmakes.tiefpunkt.com/, which is not possible for me, since the calendar is automatically generated from the ICS linked in the wiki (see https://github.com/tiefpunkt/community_calendar for reference). The generator that is running there also seems to be an older version, so the description of each event does not yet contain the information whether an event is public or only for members.

However, since I'm parsing not just one ICS but a few for the community calendar, applying some additional filtering in there would be quite tedious, so I though adapting this scaper here might be a better way.