### PR TITLE
Add timezone information (Europe/Berlin) to all entries

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -86,7 +86,7 @@ six = ">=1.9"
 webencodings = "*"
 
 [package.extras]
-all = ["genshi", "chardet (>=2.2)", "lxml"]
+all = ["chardet (>=2.2)", "genshi", "lxml"]
 chardet = ["chardet (>=2.2)"]
 genshi = ["genshi"]
 lxml = ["lxml"]
@@ -152,7 +152,7 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2022.1"
+version = "2022.2.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -217,8 +217,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -232,7 +232,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "cbcb78a9c6f777dae855082c30cd84e67ca623ae7581dbc911d40b06dd61a39d"
+content-hash = "6878282ccad54aed95680c5c953620b72aa7f83f3ec49290d481b5f831681480"
 
 [metadata.files]
 beautifulsoup4 = [
@@ -309,8 +309,8 @@ python-dateutil = [
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
-    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
-    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
+    {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
+    {file = "pytz-2022.2.1.tar.gz", hash = "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requests = "^2.27.1"
 beautifulsoup4 = "^4.10.0"
 icalendar = "^4.0.9"
 html5lib = "^1.1"
+pytz = "^2022.2.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"

--- a/wiki_kalenderscraper/__init__.py
+++ b/wiki_kalenderscraper/__init__.py
@@ -3,12 +3,14 @@
 # Kalenderscraper
 # c007, 10.06.14
 # andi, 2017+2018
+# max, 2022
 
 import os
 import datetime
 import requests
 from bs4 import BeautifulSoup
 from icalendar import Calendar, Event
+import pytz
 import json
 import re
 from itertools import groupby
@@ -144,6 +146,12 @@ class KalenderScraper:
                 entry["dtend"] = entry["dtstart"] + datetime.timedelta(
                     hours=entry["duration"]
                 )
+                
+                # Add timezone information to datetimes: Europe/Berlin
+                entry["dtstart"] = entry["dtstart"].replace(tzinfo=pytz.timezone("Europe/Berlin"))
+                entry["dtend"] = entry["dtend"].replace(tzinfo=pytz.timezone("Europe/Berlin"))
+
+                # Add dtstart and dtend to event
                 event.add("dtstart", entry["dtstart"])
                 event.add("dtend", entry["dtend"])
             else:
@@ -205,6 +213,8 @@ class KalenderScraper:
 
     def next_event_json(self):
         now = datetime.datetime.now()
+        # Add timezone information: Europe/Berlin
+        now = now.replace(tzinfo=pytz.timezone("Europe/Berlin"))
         DayL = [
             "Montag",
             "Dienstag",

--- a/wiki_kalenderscraper/__init__.py
+++ b/wiki_kalenderscraper/__init__.py
@@ -17,7 +17,14 @@ from itertools import groupby
 
 
 class KalenderScraper:
-    def __init__(self):
+    def __init__(self, tz: str="Europe/Berlin"):
+        """
+        tz: timezone as a string (e.g. 'Europe/Berlin') via pytz
+
+
+        On init, KalenderScraper scrapes the calendar data from the wiki automatically.
+        """
+        self.tz = pytz.timezone(tz)
         self.scrape()
 
     @classmethod
@@ -148,8 +155,8 @@ class KalenderScraper:
                 )
                 
                 # Add timezone information to datetimes: Europe/Berlin
-                entry["dtstart"] = entry["dtstart"].replace(tzinfo=pytz.timezone("Europe/Berlin"))
-                entry["dtend"] = entry["dtend"].replace(tzinfo=pytz.timezone("Europe/Berlin"))
+                entry["dtstart"] = entry["dtstart"].replace(tzinfo=self.tz)
+                entry["dtend"] = entry["dtend"].replace(tzinfo=self.tz)
 
                 # Add dtstart and dtend to event
                 event.add("dtstart", entry["dtstart"])
@@ -214,7 +221,7 @@ class KalenderScraper:
     def next_event_json(self):
         now = datetime.datetime.now()
         # Add timezone information: Europe/Berlin
-        now = now.replace(tzinfo=pytz.timezone("Europe/Berlin"))
+        now = now.replace(tzinfo=self.tz)
         DayL = [
             "Montag",
             "Dienstag",


### PR DESCRIPTION
This allows the online version of the ICS to display correct timezones
for events regardless of system locale